### PR TITLE
Update CAPMC to 1.32.0

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,10 @@ All notable changes to this project for v2.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2022-01-07
+
+- CAPMC version to 1.32.0 for CVE fixes
+
 ## [2.0.2] - 2021-12-01
 
 ### Changed

--- a/charts/v2.0/cray-hms-capmc/Chart.yaml
+++ b/charts/v2.0/cray-hms-capmc/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: "cray-hms-capmc"
-version: 2.0.2
+version: 2.0.3
 description: "Kubernetes resources for cray-hms-capmc"
 home: "https://github.com/Cray-HPE/hms-capmc-charts"
 sources:
@@ -13,6 +13,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.31.0"
+appVersion: "1.32.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-hms-capmc/values.yaml
+++ b/charts/v2.0/cray-hms-capmc/values.yaml
@@ -8,7 +8,7 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.31.0
+  appVersion: 1.32.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-capmc

--- a/cray-hms-capmc.compatibility.yaml
+++ b/cray-hms-capmc.compatibility.yaml
@@ -14,6 +14,7 @@ chartVersionToApplicationVersion:
   "2.0.0": "1.29.0"
   "2.0.1": "1.30.0"
   "2.0.2": "1.31.0"
+  "2.0.3": "1.32.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Alpine target being used had several CVEs. Updated which artifactory the docker file was pulling from and included an apk upgrade to help resolve current and future CVE  issues.

### Issues and Related PRs

* Resolves [CASMHMS-5302](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5302)

### Testing

No additional testing required.

Verified snyk tests did not find anymore vulnerabilities.

[Snyk run from build with CVEs](https://jenkins.algol60.net/job/Cray-HPE/job/hms-capmc/job/v1.31.0/3/artifact/2022-01-05T15-22-54-093531Z_snyk_report.html)
[Snyk run for this change](https://jenkins.algol60.net/job/Cray-HPE/job/hms-capmc/job/fix-cve/5/artifact/2022-01-07T17-22-52-287318Z_snyk_report.html)

### Risks and Mitigations

No known risks