### PR TITLE
Added pod anti-affinity.

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,7 +5,15 @@ All notable changes to this project for v2.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.4] - 2022-01-27
+
+### Changed
+
+- Added pod anti-affinity.
+
 ## [2.0.3] - 2022-01-07
+
+### Changed
 
 - CAPMC version to 1.32.0 for CVE fixes
 

--- a/charts/v2.0/cray-hms-capmc/Chart.yaml
+++ b/charts/v2.0/cray-hms-capmc/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: "cray-hms-capmc"
-version: 2.0.3
+version: 2.0.4
 description: "Kubernetes resources for cray-hms-capmc"
 home: "https://github.com/Cray-HPE/hms-capmc-charts"
 sources:

--- a/charts/v2.0/cray-hms-capmc/values.yaml
+++ b/charts/v2.0/cray-hms-capmc/values.yaml
@@ -21,6 +21,20 @@ cray-service:
   nameOverride: "cray-capmc"
   fullnameOverride: "cray-capmc"
   replicaCount: 3
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - cray-capmc
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 50%
+    type: RollingUpdate
   containers:
     cray-capmc:
       name: "cray-capmc"

--- a/cray-hms-capmc.compatibility.yaml
+++ b/cray-hms-capmc.compatibility.yaml
@@ -15,6 +15,7 @@ chartVersionToApplicationVersion:
   "2.0.1": "1.30.0"
   "2.0.2": "1.31.0"
   "2.0.3": "1.32.0"
+  "2.0.4": "1.32.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

This service has been missing pod anti-affinity.  This mod adds it to the
service chart.

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? E.G., .spec, Chart.yaml Y

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: © Copyright 2014-2020 Hewlett Packard Enterprise Development LP    ? N/A

### Issues and Related PRs

* Resolves CASMINST-3921

### Testing

Tested on:

* wasp

Was a fresh Install tested? N   Not needed
Was an Upgrade tested?      Y
Was a Downgrade tested?     Y
Was a CT test run?          Y
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

Installed new chart and upgraded to it. Verified anti-affinity by looking at the
nodes the different pods run on before and after. Downgraded when finished.

### Risks and Mitigations

Low risk, no actual chart functional changes were made.

