### PR TITLE
Fixes for Olympus power capping

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.5] - 2022-03-10
+
+### Changed
+
+- Fixes for Olympus power capping
+
 ## [2.0.4] - 2022-01-27
 
 ### Changed

--- a/charts/v2.0/cray-hms-capmc/Chart.yaml
+++ b/charts/v2.0/cray-hms-capmc/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: "cray-hms-capmc"
-version: 2.0.4
+version: 2.0.5
 description: "Kubernetes resources for cray-hms-capmc"
 home: "https://github.com/Cray-HPE/hms-capmc-charts"
 sources:
@@ -13,6 +13,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.32.0"
+appVersion: "1.33.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-hms-capmc/values.yaml
+++ b/charts/v2.0/cray-hms-capmc/values.yaml
@@ -8,7 +8,7 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.32.0
+  appVersion: 1.33.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-capmc

--- a/cray-hms-capmc.compatibility.yaml
+++ b/cray-hms-capmc.compatibility.yaml
@@ -16,6 +16,7 @@ chartVersionToApplicationVersion:
   "2.0.2": "1.31.0"
   "2.0.3": "1.32.0"
   "2.0.4": "1.32.0"
+  "2.0.5": "1.33.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Olympus power capping is disabled by default. When power cap requests are sent to Olympus nodes include enabling the power capping. Also had to change how power capping is disabled for Olympus nodes.

### Issues and Related PRs

* Resolves [CASMHMS-5399](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5399)

### Testing

Tested on:

* `hela`

Were the install/upgrade based validation checks/tests run? no
Were continuous integration tests run? Y
Was an Upgrade tested?                 Y
Was a Downgrade tested?                Y

Power capped and verified settings with CAPMC. Disabled power capping and verified settings via curl.

### Risks and Mitigations

HAS A SECURITY AUDIT BEEN RUN? Y

No known issues.
