### PR TITLE
Fix for CAPMC waiting for every power off to complete

### DIFF
--- a/changelog/v1.23.md
+++ b/changelog/v1.23.md
@@ -5,6 +5,12 @@ All notable changes to this project for v1.23.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.13] - 2022-04-11
+
+###
+
+- Only wait for power off when emulating restart
+
 ## [1.23.12] - 2021-12-01
 
 ### Changed

--- a/charts/v1.23/cray-hms-capmc/Chart.yaml
+++ b/charts/v1.23/cray-hms-capmc/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v1
 description: "Kubernetes resources for cray-hms-capmc"
 name: "cray-hms-capmc"
 home: "HMS/hms-capmc"
-version: 1.23.12
-appVersion: "1.31.0"
+version: 1.23.13
+appVersion: "1.31.1"

--- a/charts/v1.23/cray-hms-capmc/files/config.toml
+++ b/charts/v1.23/cray-hms-capmc/files/config.toml
@@ -167,3 +167,23 @@ PowerBandMin = 0
 # Administratively defined maximum allowable system power consumption,
 # specified in watts
 PowerBandMax = 0
+
+[CapmcConfiguration]
+
+# Number of workers that are available to execute in parallel for Redfish calls
+# ActionMaxWorkers = 1000
+
+# CAPMC behavior for a power action that target hardware does not support
+# Valid options: simulate, ignore, error
+#   simulate - For components that do not support GracefulRestart or
+#              ForceRestart, simulate will turn the node Off then On again
+#   ignore - Skip the component but notify the user it was ignored
+#   error - Halt the power operation and notify the user
+# OnUnsupportedAction = "simulate"
+
+# CAPMC will check power state of components when an Off request has been
+# issued. CAPMC will return from the Off request when it has verified that the
+# target components are off or if the number of retries have been exceeded.
+# WaitForOffRetries = 60
+# Amount of time to sleep between checks of component power state for Off.
+# WaitForOffSleep = 15

--- a/charts/v1.23/cray-hms-capmc/values.yaml
+++ b/charts/v1.23/cray-hms-capmc/values.yaml
@@ -8,7 +8,7 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.31.0
+  appVersion: 1.31.1
 
 hms_ca_uri: ""
 


### PR DESCRIPTION
### Summary and Scope

A previous mod implemented support for emulating restarts when the
hardware does not directly support it. It ended up causing every power
off to wait for the hardware to be off. This caused problems due to the
behavior change and a short timeout. Bumped the timeout from 1 minute to
15 minutes. This timeout is still site dependent.

### Issues and Related PRs

* Resolves CASMHMS-5480 for csm 1.0

### Testing

Tested on:

* `hela`

Were the install/upgrade based validation checks/tests run? N
Were continuous integration tests run? Y
Was an Upgrade tested?                 Y
Was a Downgrade tested?                Y

Upgraded CAPMC to fixed version, verified CAPMC returns immediately after sending power Off to target node. There were no checks by CAPMC to see if the node was off. Issues a reinit to a node and verified CAPMC waited for the node to power off before issuing the power On and returning. It was discovered on hela that mountain nodes were taking ~11 minutes to power off.

### Risks and Mitigations

HAS A SECURITY AUDIT BEEN RUN? (./runSnyk.sh) Y

No known issues.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable