### PR TITLE
CASMHMS-5458 Coordination for HMS CT Helm tests

### DIFF
--- a/changelog/v3.0.md
+++ b/changelog/v3.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v3.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.3] - 2022-06-22
+
+### Changed
+
+- updated CT tests to hms-test:3.1.0 image as part of Helm test coordination
+
 ## [3.0.2] - 2022-06-07
 
 ### Added

--- a/charts/v3.0/cray-hms-capmc/Chart.yaml
+++ b/charts/v3.0/cray-hms-capmc/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: "cray-hms-capmc"
-version: 3.0.2
+version: 3.0.3
 description: "Kubernetes resources for cray-hms-capmc"
 home: "https://github.com/Cray-HPE/hms-capmc-charts"
 sources:

--- a/charts/v3.0/cray-hms-capmc/Chart.yaml
+++ b/charts/v3.0/cray-hms-capmc/Chart.yaml
@@ -13,6 +13,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.1.0"
+appVersion: "2.2.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v3.0/cray-hms-capmc/values.yaml
+++ b/charts/v3.0/cray-hms-capmc/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.1.0
-  testVersion: 2.1.0
+  appVersion: 2.2.0
+  testVersion: 2.2.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-capmc
@@ -18,7 +18,7 @@ image:
 tests:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/cray-capmc-test
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
 
 hms_ca_uri: ""
 

--- a/charts/v3.0/cray-hms-capmc/values.yaml
+++ b/charts/v3.0/cray-hms-capmc/values.yaml
@@ -10,14 +10,15 @@
 global:
   appVersion: 2.1.0
   testVersion: 2.1.0
-tests:
-  image:
-    repository: artifactory.algol60.net/csm-docker/stable/cray-capmc-test
-    pullPolicy: IfNotPresent
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-capmc
   pullPolicy: IfNotPresent
+
+tests:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/cray-capmc-test
+    pullPolicy: Always
 
 hms_ca_uri: ""
 

--- a/cray-hms-capmc.compatibility.yaml
+++ b/cray-hms-capmc.compatibility.yaml
@@ -21,6 +21,7 @@ chartVersionToApplicationVersion:
   "3.0.0": "2.0.0"
   "3.0.1": "2.1.0"
   "3.0.2": "2.1.0"
+  "3.0.3": "2.2.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

This PR includes the following changes:

- Update CT tests to stable hms-test:3.1.0 image (upgrades pytest and tavern to work around python issue43798)
- Pull Alpine base image from correct location in algol60 artifactory
- CT test cleanup

### Issues and Related PRs

* Partially resolves CASMHMS-5458.

### Testing

This change was tested by deploying the updated version of the service and chart onto Mug, executing the Helm CT tests, and verifying that they passed.

Was a fresh Install tested? N
Was an Upgrade tested? Y
Was a Downgrade tested? N

### Risks and Mitigations

Low risk, test update.