### PR TITLE
CASMHMS-5612 Helm CT test enhancements and CVE remediation

### DIFF
--- a/changelog/v3.0.md
+++ b/changelog/v3.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v3.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.5] - 2022-07-18
+
+### Changed
+
+- Updated CT tests to hms-test:3.2.0 image to pick up Helm test enhancements
+
 ## [3.0.4] - 2022-07-01
 
 ### Changed
@@ -15,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- updated CT tests to hms-test:3.1.0 image as part of Helm test coordination
+- Updated CT tests to hms-test:3.1.0 image as part of Helm test coordination
 
 ## [3.0.2] - 2022-06-07
 

--- a/changelog/v3.0.md
+++ b/changelog/v3.0.md
@@ -5,11 +5,11 @@ All notable changes to this project for v3.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.0.5] - 2022-07-18
+## [3.0.5] - 2022-07-20
 
 ### Changed
 
-- Updated CT tests to hms-test:3.2.0 image to pick up Helm test enhancements
+- Updated CT tests to hms-test:3.2.0 image to pick up Helm test enhancements and CVE fixes
 
 ## [3.0.4] - 2022-07-01
 

--- a/charts/v1.23/cray-hms-capmc/requirements.lock
+++ b/charts/v1.23/cray-hms-capmc/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: cray-service
   repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
-  version: 2.4.9
-digest: sha256:c4181e723d3dd54c9afec3d6dd5f051f05dbdae82ae5f1e6dea8435621ec22f4
-generated: "2022-07-18T17:49:47.261102-05:00"
+  version: 2.4.8
+digest: sha256:9d9b09ad522017518dc51680032e41d7002d7f1ee01e0aa243a6bc3cbe013066
+generated: "2021-09-29T17:27:09.364329-05:00"

--- a/charts/v1.23/cray-hms-capmc/requirements.lock
+++ b/charts/v1.23/cray-hms-capmc/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: cray-service
   repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
-  version: 2.4.8
-digest: sha256:9d9b09ad522017518dc51680032e41d7002d7f1ee01e0aa243a6bc3cbe013066
-generated: "2021-09-29T17:27:09.364329-05:00"
+  version: 2.4.9
+digest: sha256:c4181e723d3dd54c9afec3d6dd5f051f05dbdae82ae5f1e6dea8435621ec22f4
+generated: "2022-07-18T17:49:47.261102-05:00"

--- a/charts/v3.0/cray-hms-capmc/Chart.yaml
+++ b/charts/v3.0/cray-hms-capmc/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: "cray-hms-capmc"
-version: 3.0.4
+version: 3.0.5
 description: "Kubernetes resources for cray-hms-capmc"
 home: "https://github.com/Cray-HPE/hms-capmc-charts"
 sources:
@@ -13,6 +13,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.3.0"
+appVersion: "2.4.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v3.0/cray-hms-capmc/values.yaml
+++ b/charts/v3.0/cray-hms-capmc/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.3.0
-  testVersion: 2.3.0
+  appVersion: 2.4.0
+  testVersion: 2.4.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-capmc

--- a/cray-hms-capmc.compatibility.yaml
+++ b/cray-hms-capmc.compatibility.yaml
@@ -23,6 +23,7 @@ chartVersionToApplicationVersion:
   "3.0.2": "2.1.0"
   "3.0.3": "2.2.0"
   "3.0.4": "2.3.0"
+  "3.0.5": "2.4.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

This PR includes the following changes for the Helm CT tests:

- kill the istio sidecar after the tests run to save wait time
- remove build dependencies from final test image that aren't needed to run the tests
- revert the test base image to alpine:3.15 to resolve CVEs

### Issues and Related PRs

* Partially resolves CASMHMS-5612.

### Testing

This change was tested by deploying a new version of an HMS service on Mug which pulled in the latest version of the hms-test image, executing its Helm CT tests, and verifying that they passed. Also verified that the test pod was no longer stuck in "NotReady" after the tests completed. Lastly, verified the change in the runCT environment and confirmed that it passed its Snyk checks that were previously failing.

Was a fresh Install tested? N
Was an Upgrade tested? Y
Was a Downgrade tested? N

### Risks and Mitigations

Low risk, minor test changes and CVE remediation.