### PR TITLE
Use Controls.Deep PATCH for Olympus power capping

### DIFF
--- a/changelog/v3.0.md
+++ b/changelog/v3.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v3.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.6] - 2022-08-01
+
+### Changed
+
+- Converted CAPMC to use Controls.Deep PATCH for Olympus power capping
+
 ## [3.0.5] - 2022-07-20
 
 ### Changed

--- a/charts/v3.0/cray-hms-capmc/Chart.yaml
+++ b/charts/v3.0/cray-hms-capmc/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: "cray-hms-capmc"
-version: 3.0.5
+version: 3.0.6
 description: "Kubernetes resources for cray-hms-capmc"
 home: "https://github.com/Cray-HPE/hms-capmc-charts"
 sources:
@@ -13,6 +13,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.4.0"
+appVersion: "2.5.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v3.0/cray-hms-capmc/values.yaml
+++ b/charts/v3.0/cray-hms-capmc/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.4.0
-  testVersion: 2.4.0
+  appVersion: 2.5.0
+  testVersion: 2.5.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-capmc

--- a/cray-hms-capmc.compatibility.yaml
+++ b/cray-hms-capmc.compatibility.yaml
@@ -24,6 +24,7 @@ chartVersionToApplicationVersion:
   "3.0.3": "2.2.0"
   "3.0.4": "2.3.0"
   "3.0.5": "2.4.0"
+  "3.0.6": "2.5.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Olympus hardware doesn't allow multiple power cap controls to be modified at the same time but there is something called a deep patch that is available. Converted CAPMC to use the deep patch mechanism for Olympus nodes.

### Issues and Related PRs

* Resolves [CASMHMS-5436](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5436)

### Testing

Tested on:

* `loki`

Upgraded to test CAPMC and verified power cap setting can be applied with the newer CAPMC using the deep patch.

Were the install/upgrade based validation checks/tests run? N
Were continuous integration tests run? Y
Was an Upgrade tested?                 Y
Was a Downgrade tested?                Y

### Risks and Mitigations

HAS A SECURITY AUDIT BEEN RUN? (./runSnyk.sh) Y
ARE THERE KNOWN ISSUES WITH THESE CHANGES? N
ANY OTHER SPECIAL CONSIDERATIONS? N

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable