### PR TITLE
CASMHMS-5468 CAPMC/CAPMC-lite tests for HMTH

### DIFF
--- a/changelog/v3.0.md
+++ b/changelog/v3.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v3.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.7] - 2022-12-07
+
+### Changed
+
+- Updated CAPMC CT tests to use hms-test:4.0.0 image for HMTH
+
 ## [3.0.6] - 2022-08-01
 
 ### Changed

--- a/charts/v3.0/cray-hms-capmc/Chart.yaml
+++ b/charts/v3.0/cray-hms-capmc/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: "cray-hms-capmc"
-version: 3.0.6
+version: 3.0.7
 description: "Kubernetes resources for cray-hms-capmc"
 home: "https://github.com/Cray-HPE/hms-capmc-charts"
 sources:
@@ -13,6 +13,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.5.0"
+appVersion: "2.6.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v3.0/cray-hms-capmc/templates/tests/test-functional.yaml
+++ b/charts/v3.0/cray-hms-capmc/templates/tests/test-functional.yaml
@@ -33,4 +33,4 @@ spec:
           image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
           imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
           command: ["/bin/sh", "-c"]
-          args: [ "entrypoint.sh functional -c /src/libs/tavern_global_config.yaml -p /src/app"]
+          args: ["entrypoint.sh tavern -c /src/libs/tavern_global_config.yaml -p /src/app/api/1-non-disruptive"]

--- a/charts/v3.0/cray-hms-capmc/templates/tests/test-smoke.yaml
+++ b/charts/v3.0/cray-hms-capmc/templates/tests/test-smoke.yaml
@@ -33,4 +33,4 @@ spec:
           image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
           imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
           command: ["/bin/sh", "-c"]
-          args: [ "entrypoint.sh smoke -f smoke.json -u http://cray-capmc"]
+          args: ["entrypoint.sh smoke -f smoke.json -u http://cray-capmc"]

--- a/charts/v3.0/cray-hms-capmc/values.yaml
+++ b/charts/v3.0/cray-hms-capmc/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.5.0
-  testVersion: 2.5.0
+  appVersion: 2.6.0
+  testVersion: 2.6.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-capmc
@@ -17,7 +17,7 @@ image:
 
 tests:
   image:
-    repository: artifactory.algol60.net/csm-docker/stable/cray-capmc-test
+    repository: artifactory.algol60.net/csm-docker/stable/cray-capmc-hmth-test
     pullPolicy: IfNotPresent
 
 hms_ca_uri: ""

--- a/cray-hms-capmc.compatibility.yaml
+++ b/cray-hms-capmc.compatibility.yaml
@@ -25,6 +25,7 @@ chartVersionToApplicationVersion:
   "3.0.4": "2.3.0"
   "3.0.5": "2.4.0"
   "3.0.6": "2.5.0"
+  "3.0.7": "2.6.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

This PR consists of the following changes:

- Update CAPMC CT tests to use latest hms-test:4.0.0 image
- Break out CAPMC CT tests into non-disruptive, disruptive, destructive, and build-pipeline-only test buckets
- Adds many new API tests that execute in the runCT environment in the build pipeline (also able to run on live systems but need to be careful doing this for the disruptive and destructive tests)

### Issues and Related PRs

* Resolves [CASMHMS-5468](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5468).

### Testing

- Tests run in the runCT build pipeline environment in GitHub Actions for each branch push and PR.
- Also deployed and ran the non-disruptive tests on Mug and Surtur to verify that they behave as expected.

### Risks and Mitigations

Adding many new API tests that will gate CAPMC changes if breakages occur.