### PR TITLE
CASMHMS-5875 Centralize setting of power operation polling for CT tests and lower the limits for build pipeline

### DIFF
--- a/changelog/v3.0.md
+++ b/changelog/v3.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v3.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.8] - 2023-01-04
+
+### Changed
+
+- Centralized the setting of power operation polling for CT tests and lowered the limits for the build pipeline
+
 ## [3.0.7] - 2022-12-07
 
 ### Changed

--- a/charts/v3.0/cray-hms-capmc/Chart.yaml
+++ b/charts/v3.0/cray-hms-capmc/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: "cray-hms-capmc"
-version: 3.0.7
+version: 3.0.8
 description: "Kubernetes resources for cray-hms-capmc"
 home: "https://github.com/Cray-HPE/hms-capmc-charts"
 sources:
@@ -13,6 +13,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.6.0"
+appVersion: "2.7.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v3.0/cray-hms-capmc/templates/tests/test-functional.yaml
+++ b/charts/v3.0/cray-hms-capmc/templates/tests/test-functional.yaml
@@ -33,4 +33,4 @@ spec:
           image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
           imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
           command: ["/bin/sh", "-c"]
-          args: ["entrypoint.sh tavern -c /src/libs/tavern_global_config.yaml -p /src/app/api/1-non-disruptive"]
+          args: ["entrypoint.sh tavern -c /src/app/tavern_global_config_ct_test_real_hardware.yaml -p /src/app/api/1-non-disruptive"]

--- a/charts/v3.0/cray-hms-capmc/templates/tests/test-functional.yaml
+++ b/charts/v3.0/cray-hms-capmc/templates/tests/test-functional.yaml
@@ -33,4 +33,4 @@ spec:
           image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
           imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
           command: ["/bin/sh", "-c"]
-          args: ["entrypoint.sh tavern -c /src/app/tavern_global_config_ct_test_real_hardware.yaml -p /src/app/api/1-non-disruptive"]
+          args: ["entrypoint.sh tavern -c /src/app/tavern_global_config_ct_test_production.yaml -p /src/app/api/1-non-disruptive"]

--- a/charts/v3.0/cray-hms-capmc/values.yaml
+++ b/charts/v3.0/cray-hms-capmc/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.6.0
-  testVersion: 2.6.0
+  appVersion: 2.7.0
+  testVersion: 2.7.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-capmc

--- a/cray-hms-capmc.compatibility.yaml
+++ b/cray-hms-capmc.compatibility.yaml
@@ -26,6 +26,7 @@ chartVersionToApplicationVersion:
   "3.0.5": "2.4.0"
   "3.0.6": "2.5.0"
   "3.0.7": "2.6.0"
+  "3.0.8": "2.7.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

This change centralizes the settings for the power operation polling of the CAPMC CT tests and adds them to the global configuration. It also breaks out the configuration into emulated vs. real hardware configurations in order to save time in the build pipeline since the power operations complete faster with emulated hardware.

### Issues and Related PRs

* Resolves CASMHMS-5875.

### Testing

Ran the CT tests with the updated configuration in the build pipeline to verify that they passed and executed more quickly than before (test runtime went from about 14 minutes down to 6.5). Also deployed the changes on Surtur and ran the updated chart to confirm that the CT tests run correctly on a live system with the new configuration file for production environments.

### Risks and Mitigations

Low risk.