### PR TITLE
New chart for CAPMC that is more shim than service

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-2022 Cray / HPE
+Copyright (c) 2021-2023 Cray / HPE
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/changelog/v4.0.md
+++ b/changelog/v4.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v4.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.1] - 2023-01-13
+
+### Changed
+
+- Fix PCS URL handling
+
 ## [4.0.0] - 2023-01-10
 
 ### Changed

--- a/changelog/v4.0.md
+++ b/changelog/v4.0.md
@@ -1,0 +1,12 @@
+# Changelog for v4.0
+
+All notable changes to this project for v4.0.Z will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [4.0.0] - 2023-01-10
+
+### Changed
+
+- Converted xname_[on/off/reinit] and get_xname_status to use PCS for power operations

--- a/charts/v4.0/cray-hms-capmc/.gitignore
+++ b/charts/v4.0/cray-hms-capmc/.gitignore
@@ -1,0 +1,2 @@
+# by default we'll ignore any subcharts included, but simply adjust this if need be
+charts/*

--- a/charts/v4.0/cray-hms-capmc/Chart.yaml
+++ b/charts/v4.0/cray-hms-capmc/Chart.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v2
+name: "cray-hms-capmc"
+version: 4.0.0
+description: "Kubernetes resources for cray-hms-capmc"
+home: "https://github.com/Cray-HPE/hms-capmc-charts"
+sources:
+  - "https://github.com/Cray-HPE/hms-capmc"
+dependencies:
+  - name: cray-service
+    version: "~7.0.0"
+    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+maintainers:
+  - name: Hardware Management
+    url: https://github.com/orgs/Cray-HPE/teams/hardware-management
+appVersion: "3.0.0"
+annotations:
+  artifacthub.io/license: "MIT"

--- a/charts/v4.0/cray-hms-capmc/Chart.yaml
+++ b/charts/v4.0/cray-hms-capmc/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: "cray-hms-capmc"
-version: 4.0.0
+version: 4.0.1
 description: "Kubernetes resources for cray-hms-capmc"
 home: "https://github.com/Cray-HPE/hms-capmc-charts"
 sources:
@@ -13,6 +13,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "3.0.0"
+appVersion: "3.1.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v4.0/cray-hms-capmc/files/config.toml
+++ b/charts/v4.0/cray-hms-capmc/files/config.toml
@@ -1,0 +1,189 @@
+# Copyright 2019-2023 Hewlett Packard Enterprise Development LP
+#
+# This config file describes CAPMC operational configuration parameters.
+#
+
+# The NodeRules section describes rules/guidelines for CAPMC node control.
+# The get_note_rules API returns these values.
+[NodeRules]
+
+# Minimum time, in seconds, which a node must reamin in the off state
+# after a shutdown and power off operation. Use -1 for no limit.
+MinOffTime = -1
+
+# Maximum time, in seconds, which a node may be in the off state. Use -1
+# for no limit.
+MaxOffTime = -1
+
+# The NodeRules.Off subsection describes rules/guidelines for node_off.
+[NodeRules.Off]
+
+# Approximate time, in seconds, for a node cleanly shutdown and power off.
+Latency = 60
+
+# Maximum number of nodes which may be powered off at once. Use -1 for no limit.
+MaxRequest = -1
+
+# The NodeRules.On subsection describes rules/guidelines for node_on.
+[NodeRules.On]
+
+# Approximate time, in seconds, for a node to power on and boot to Ready state.
+Latency = 120
+
+# Maximum number of nodes which may be powered on at once. Use -1 for no limit.
+MaxRequest = -1
+
+# The NodeRules.Reinit subsection describes rules/guidelines for node_reint.
+[NodeRules.Reinit]
+
+# Approximate time, in seconds, for a node cleanly shutdown, power off, power
+# on, and boot to Ready state.
+Latency = 180
+
+# Maximum number of nodes allowed to be included in a node reinit request.
+# Use -1 for no limit.
+MaxRequest = -1
+
+# The PowerControls section describes guidelines/policy/rules applying
+# generally to CAPMC power off (down) / on (up) of hardware. These values
+# should only be edited under direction from Cray service personnel.
+[PowerControls]
+
+# The PowerControls.ForceOff subsection describes guidelines/policy/rules
+# applying to a force off action.
+[PowerControls.ForceOff]
+
+# Block components with these roles from power force off actions.
+# BlockRole = ["Management"]
+
+# An ordered list desribing the power force off sequence for components.
+ComponentSequence = ["Node", "ComputeModule", "HSNBoard", "RouterModule", "Chassis", "CabinetPDUOutlet", "CabinetPDUPowerConnector"]
+
+# Mapping of CAPMC force off to Redfish ResetType.
+ResetType = ["ForceOff"]
+
+# The PowerControls.ForceOn subsection describes guidelines/policy/rules
+# applying to a force on action.
+[PowerControls.ForceOn]
+
+# Block components with these roles from power force on actions.
+# BlockRole = ["Management"]
+
+# An ordered list desribing the power force on sequence for components.
+ComponentSequence = ["CabinetPDUPowerConnector", "CabinetPDUOutlet", "Chassis", "RouterModule", "HSNBoard", "ComputeModule", "Node"]
+
+# Mapping of CAPMC force on to Redfish ResetType.
+ResetType = ["ForceOn"]
+
+# The PowerControls.ForceRestart subsection describes guidelines/policy/rules
+# applying to a force restart (reinit) action.
+[PowerControls.ForceRestart]
+
+# Block components with these roles from power force restart actions.
+# BlockRole = ["Management"]
+
+# An ordered list desribing the power force restart sequence for components.
+ComponentSequence = ["Node"]
+
+# Mapping of CAPMC force restart (reinit) to Redfish ResetType.
+ResetType = ["ForceRestart", "PowerCycle"]
+
+# The PowerControls.off subsection describes guidelines/policy/rules
+# applying to an off action.
+[PowerControls.Off]
+
+# Block components with these roles from power off actions.
+# BlockRole = ["Management"]
+
+# An ordered list desribing the power off sequence for components.
+ComponentSequence = ["Node", "ComputeModule", "HSNBoard", "RouterModule", "Chassis", "CabinetPDUOutlet", "CabinetPDUPowerConnector"]
+
+# Mapping of CAPMC (graceful) off to Redfish ResetType.
+ResetType = ["GracefulShutdown", "PushPowerButton", "Off"]
+
+# The PowerControls.On subsection describes guidelines/policy/rules
+# applying to an on action.
+[PowerControls.On]
+
+# Block components with these roles from power on actions.
+# BlockRole = ["Management"]
+
+# An ordered list desribing the power on sequence for components.
+ComponentSequence = ["CabinetPDUPowerConnector", "CabinetPDUOutlet", "Chassis", "RouterModule", "HSNBoard", "ComputeModule", "Node"]
+
+# Mapping of CAPMC (graceful) on to Redfish ResetType.
+ResetType = ["On"]
+
+# The PowerControls.Resetart subsection describes guidelines/policy/rules
+# applying to a restart (AKA reinit) action.
+[PowerControls.Restart]
+
+# Block components with these roles from power restart actions.
+# BlockRole = ["Management"]
+
+# An ordered list desribing the power restart sequence for components.
+ComponentSequence = ["Node"]
+
+# Mapping of CAPMC (graceful) restart to Redfish ResetType.
+ResetType = ["GracefulRestart"]
+
+# NOTE NMI is a future CAPMC enhancement. Actual configuration TBD.
+[PowerControls.NMI]
+
+# Block components with these roles from a NMI action.
+# NOTE: "" covers any component without an assigned role.
+# BlockRole = ["Management"]
+
+# An ordered list desribing the NMI sequence for components.
+ComponentSequence = ["Node"]
+
+# Mapping of CAPMC NMI to Redfish ResetType.
+ResetType = ["Nmi"]
+
+[SystemParameters]
+
+# Administratively defined upper limit on system power
+PowerCapTarget = 0
+
+# System power level, which if crossed, will result in Cray management software
+# emitting over power budget warnings
+PowerThreshold = 0
+
+# Additional static system wide power overhead which is unreported, specified
+# in watts
+StaticPower = 0
+
+# True if out-of-band HSS power ramp rate limiting features are enabled
+RampLimited = false
+
+# Administratively defined maximum rate of change (increasing or decreasing) in
+# system wide power consumption, specified in watts per minute
+RampLimit = 2000000
+
+# Administratively defined minimum allowable system power consumption,
+# specified in watts
+PowerBandMin = 0
+
+# Administratively defined maximum allowable system power consumption,
+# specified in watts
+PowerBandMax = 0
+
+[CapmcConfiguration]
+
+# Number of workers that are available to execute in parallel for Redfish calls
+# ActionMaxWorkers = 1000
+
+# CAPMC behavior for a power action that target hardware does not support
+# Valid options: simulate, ignore, error
+#   simulate - For components that do not support GracefulRestart or
+#              ForceRestart, simulate will turn the node Off then On again
+#   ignore - Skip the component but notify the user it was ignored
+#   error - Halt the power operation and notify the user
+# OnUnsupportedAction = "simulate"
+
+# CAPMC will check power state of components when an Off request has been
+# issued. CAPMC will return from the Off request when it has verified that the
+# target components are off or if the number of retries have been exceeded.
+# WaitForOffRetries = 60
+# Amount of time to sleep between checks of component power state for Off.
+# WaitForOffSleep = 15

--- a/charts/v4.0/cray-hms-capmc/templates/configmap.yaml
+++ b/charts/v4.0/cray-hms-capmc/templates/configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cray-capmc-configuration
+  namespace: services
+data:
+  config.toml: |-
+{{ .Files.Get "files/config.toml" | indent 4 }}
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: capmc-cacert-info
+data:
+  CA_URI: "{{ .Values.hms_ca_uri }}"
+

--- a/charts/v4.0/cray-hms-capmc/templates/tests/test-functional.yaml
+++ b/charts/v4.0/cray-hms-capmc/templates/tests/test-functional.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-functional"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "1" #run this after smoke!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-functional"
+
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-functional"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-functional"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "functional"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: ["entrypoint.sh tavern -c /src/app/tavern_global_config_ct_test_production.yaml -p /src/app/api/1-non-disruptive"]

--- a/charts/v4.0/cray-hms-capmc/templates/tests/test-smoke.yaml
+++ b/charts/v4.0/cray-hms-capmc/templates/tests/test-smoke.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-smoke"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1" #run this first!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-smoke"
+
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-smoke"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-smoke"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "smoke"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: ["entrypoint.sh smoke -f smoke.json -u http://cray-capmc"]

--- a/charts/v4.0/cray-hms-capmc/values.yaml
+++ b/charts/v4.0/cray-hms-capmc/values.yaml
@@ -8,7 +8,7 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 3.0.0
+  appVersion: 3.1.0
   testVersion: 3.0.0
 
 image:
@@ -52,6 +52,8 @@ cray-service:
       env:
         - name: HSM_URL
           value: "http://cray-smd"
+        - name: PCS_URL
+          value: "http://cray-power-control"
         - name: CAPMC_CONFIG
           value: "/usr/local/etc/capmc-service/config.toml"
         - name: VAULT_ADDR

--- a/charts/v4.0/cray-hms-capmc/values.yaml
+++ b/charts/v4.0/cray-hms-capmc/values.yaml
@@ -9,7 +9,7 @@
 
 global:
   appVersion: 3.1.0
-  testVersion: 3.0.0
+  testVersion: 3.1.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-capmc

--- a/charts/v4.0/cray-hms-capmc/values.yaml
+++ b/charts/v4.0/cray-hms-capmc/values.yaml
@@ -1,0 +1,105 @@
+# Please refer to https://stash.us.cray.com/projects/CLOUD/repos/cray-charts/browse/stable/cray-service/values.yaml?at=refs%2Fheads%2Fmaster
+# for more info on values you can set/override
+# Note that cray-service.containers[*].image and cray-service.initContainers[*].image map values are one of the only structures that
+# differ from the standard kubernetes container spec:
+# image:
+#   repository: ""
+#   tag: "" (default = "latest")
+#   pullPolicy: "" (default = "IfNotPresent")
+
+global:
+  appVersion: 3.0.0
+  testVersion: 3.0.0
+
+image:
+  repository: artifactory.algol60.net/csm-docker/stable/cray-capmc
+  pullPolicy: IfNotPresent
+
+tests:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/cray-capmc-hmth-test
+    pullPolicy: IfNotPresent
+
+hms_ca_uri: ""
+
+cray-service:
+  type: "Deployment"
+  nameOverride: "cray-capmc"
+  fullnameOverride: "cray-capmc"
+  replicaCount: 3
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - cray-capmc
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 50%
+    type: RollingUpdate
+  containers:
+    cray-capmc:
+      name: "cray-capmc"
+      image:
+        repository: artifactory.algol60.net/csm-docker/stable/cray-capmc
+      ports:
+        - name: http
+          containerPort: 27777
+      env:
+        - name: HSM_URL
+          value: "http://cray-smd"
+        - name: CAPMC_CONFIG
+          value: "/usr/local/etc/capmc-service/config.toml"
+        - name: VAULT_ADDR
+          value: "http://cray-vault.vault:8200"
+        - name: VAULT_SKIP_VERIFY
+          value: "true"
+        - name: CAPMC_CA_URI
+          valueFrom:
+            configMapKeyRef:
+              name: capmc-cacert-info
+              key: CA_URI
+      livenessProbe:
+        httpGet:
+          port: 27777
+          path: /capmc/v1/liveness
+        initialDelaySeconds: 10
+        periodSeconds: 20
+      readinessProbe:
+        httpGet:
+          port: 27777
+          path: /capmc/v1/readiness
+        initialDelaySeconds: 5
+        periodSeconds: 60
+      resources:
+        limits:
+          cpu: "10"
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 128Mi
+      volumeMounts:
+        - name: cray-capmc-config-vol
+          mountPath: /usr/local/etc/capmc-service/config.toml
+          readOnly: true
+          subPath: config.toml
+        - name: cray-pki-cacert-vol
+          mountPath: /usr/local/cray-pki
+  volumes:
+    cray-capmc-config-vol:
+      name: cray-capmc-config-vol
+      configMap:
+        name: cray-capmc-configuration
+    cray-pki-cacert-vol:
+      name: cray-pki-cacert-vol
+      configMap:
+        name: cray-configmap-ca-public-key
+
+  ingress:
+    enabled: true
+    uri: " "
+    prefix: /apis/capmc

--- a/cray-hms-capmc.compatibility.yaml
+++ b/cray-hms-capmc.compatibility.yaml
@@ -29,6 +29,7 @@ chartVersionToApplicationVersion:
   "3.0.7": "2.6.0"
   "3.0.8": "2.7.0"
   "4.0.0": "3.0.0"
+  "4.0.1": "3.1.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []

--- a/cray-hms-capmc.compatibility.yaml
+++ b/cray-hms-capmc.compatibility.yaml
@@ -5,6 +5,7 @@ chartVersionToCSMVersion:
   "^1.23.12": "~1.0.0"
   ">=2.0.0": "~1.2.0" # Chart Version: 2.0.0 <= x.y.z, CSM Version: 1.2.0 <= x.y.z < 1.3.0
   ">=3.0.0": "~1.3.0"
+  ">=4.0.0": "~1.4.0"
 
 # The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
@@ -27,6 +28,7 @@ chartVersionToApplicationVersion:
   "3.0.6": "2.5.0"
   "3.0.7": "2.6.0"
   "3.0.8": "2.7.0"
+  "4.0.0": "3.0.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Convert the CAPMC xname_[on/off/reinit] and get_xname_status APIs into shims that call PCS.

### Issues and Related PRs

* Resolves [CASMHMS-5736](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5736)

### Testing

Tested on:

* unit tests
* Tavern tests with simulated environment
* Shandy

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) N
Were continuous integration tests run? Y/N  Y
Was an Upgrade tested? Y
Was a Downgrade tested? N - left in place for further testing of other group tools

Verified that all valid unit and tavern tests passed. Some unit tests were removed due to CAPMC not needing to do certain behaviors anymore.

### Risks and Mitigations

HAS A SECURITY AUDIT BEEN RUN? Y
ARE THERE KNOWN ISSUES WITH THESE CHANGES? N
ANY OTHER SPECIAL CONSIDERATIONS? N
