### PR TITLE
CASMHMS-5930 Move CAPMC get_power_cap_capabilities test into optional test stage

### DIFF
--- a/changelog/v4.0.md
+++ b/changelog/v4.0.md
@@ -5,6 +5,13 @@ All notable changes to this project for v4.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.2] - 2023-02-28
+
+### Fixed
+
+- Fixed bug in CT tests that use multiple verify response functions
+- Pulled get_power_cap_capabilities test into separate test stage
+
 ## [4.0.1] - 2023-01-13
 
 ### Changed

--- a/charts/v4.0/cray-hms-capmc/Chart.yaml
+++ b/charts/v4.0/cray-hms-capmc/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: "cray-hms-capmc"
-version: 4.0.1
+version: 4.0.2
 description: "Kubernetes resources for cray-hms-capmc"
 home: "https://github.com/Cray-HPE/hms-capmc-charts"
 sources:
@@ -13,6 +13,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "3.1.0"
+appVersion: "3.3.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v4.0/cray-hms-capmc/templates/tests/check-hardware.yaml
+++ b/charts/v4.0/cray-hms-capmc/templates/tests/check-hardware.yaml
@@ -2,25 +2,25 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ .Release.Name }}-test-functional"
+  name: "{{ .Release.Name }}-check-hardware"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-    "helm.sh/hook-weight": "1" #run this after smoke!
+    "helm.sh/hook-weight": "2" #run this after smoke and functional
 
   labels:
-    app.kubernetes.io/name: "{{ .Release.Name }}-test-functional"
+    app.kubernetes.io/name: "{{ .Release.Name }}-check-hardware"
 
 spec:
   backoffLimit: 0
   template:
     metadata:
-      name: "{{ .Release.Name }}-test-functional"
+      name: "{{ .Release.Name }}-check-hardware"
       annotations:
         "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
       labels:
         app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
-        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-functional"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-check-hardware"
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     spec:
       restartPolicy: Never
@@ -29,8 +29,8 @@ spec:
         runAsUser: 65534
         runAsGroup: 65534
       containers:
-        - name: "functional"
+        - name: "check-hardware"
           image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
           imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
           command: ["/bin/sh", "-c"]
-          args: ["entrypoint.sh tavern -c /src/app/tavern_global_config_ct_test_production.yaml -p /src/app/api/2-non-disruptive"]
+          args: ["entrypoint.sh tavern -c /src/app/tavern_global_config_ct_test_production.yaml -p /src/app/api/1-hardware-checks"]

--- a/charts/v4.0/cray-hms-capmc/values.yaml
+++ b/charts/v4.0/cray-hms-capmc/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 3.1.0
-  testVersion: 3.1.0
+  appVersion: 3.3.0
+  testVersion: 3.3.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-capmc

--- a/cray-hms-capmc.compatibility.yaml
+++ b/cray-hms-capmc.compatibility.yaml
@@ -30,6 +30,7 @@ chartVersionToApplicationVersion:
   "3.0.8": "2.7.0"
   "4.0.0": "3.0.0"
   "4.0.1": "3.1.0"
+  "4.0.2": "3.3.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

This PR moves the CAPMC get_power_cap_capabilities CT test into the optional hardware checks stage of the CSM validation steps since it often fails but this functionality is not critical for the usage or management of the system. It also fixes a bug in several tests where certain validation functions were being silently skipped.

### Issues and Related PRs

* Resolves CASMHMS-5930.
* Partially resolves CASMHMS-5924.

### Testing

This change was tested on Surtur by deploying the new version of CAPMC and verifying that the get_power_cap_capabilities CT test was no longer included in the set of functional tests executed and that it instead ran as part of the hardware checks test stage. The changes were also tested locally using the HMS simulation environment by injecting failures into the test cases that previously had checks that were being skipped and verifying that they now correctly cause test failures instead of silently passing.

Was a fresh Install tested? N
Was an Upgrade tested? Y
Was a Downgrade tested? Y

### Risks and Mitigations

Low risk, should reduce unnecessary triage efforts.