### PR TITLE
CASMHMS-6148: Parse PowerConsumedWatts for any data type

### DIFF
--- a/changelog/v4.0.md
+++ b/changelog/v4.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v4.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.3] - 2023-04-15
+
+### Added
+
+- Parse PowerConsumedWatts for any data type
+
 ## [4.0.2] - 2023-02-28
 
 ### Fixed

--- a/changelog/v4.0.md
+++ b/changelog/v4.0.md
@@ -5,7 +5,7 @@ All notable changes to this project for v4.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.0.3] - 2023-04-15
+## [4.0.3] - 2023-04-24
 
 ### Added
 

--- a/charts/v4.0/cray-hms-capmc/Chart.yaml
+++ b/charts/v4.0/cray-hms-capmc/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: "cray-hms-capmc"
-version: 4.0.2
+version: 4.0.3
 description: "Kubernetes resources for cray-hms-capmc"
 home: "https://github.com/Cray-HPE/hms-capmc-charts"
 sources:
@@ -13,6 +13,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "3.3.0"
+appVersion: "3.6.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v4.0/cray-hms-capmc/values.yaml
+++ b/charts/v4.0/cray-hms-capmc/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 3.3.0
-  testVersion: 3.3.0
+  appVersion: 3.6.0
+  testVersion: 3.6.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-capmc

--- a/cray-hms-capmc.compatibility.yaml
+++ b/cray-hms-capmc.compatibility.yaml
@@ -31,6 +31,7 @@ chartVersionToApplicationVersion:
   "4.0.0": "3.0.0"
   "4.0.1": "3.1.0"
   "4.0.2": "3.3.0"
+  "4.0.3": "3.6.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

The Paradise redfish Power endpoint presents the consumed watts value as a float.  All prior platforms have presented it as an integer value and thus the capmc data structure for holding it declared it as an int.  This caused json.Unmarshal() to fail on Paradise because it enforces strict type checking.

The fix here is to change the int type to an interface{} type so that it can hold a value of any type.  We then convert any floats we read to an int (by rounding).  We chose to do this rather than simply changing the type from an int to a float so that we don't break any customer code that may be doing the same thing we were doing (expecting an int rather than a float).

Adopted app version 3.6.0 for CSM 1.5.2 and 1.6 (helm chart 4.0.3)

## Issues and Related PRs

* Resolves CASMHMS-6148

## Testing

Tested on:

  * tyr

Test description:

With a patched SMD in place, verified that capmc would convert floats to ints properly when ran against Paradise nodes.  Then verified that capmc could power cap both Paradise and Bard Peak compute nodes.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable