### PR TITLE
CASMHMS-6261: Updated dependences for Kubernetes 1.24

### DIFF
--- a/changelog/v5.0.md
+++ b/changelog/v5.0.md
@@ -9,4 +9,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update cray-service chart to ~10.0.6 and docker-kubectl image to 1.24.17
+- Update cray-service chart to ~10.0.6

--- a/changelog/v5.0.md
+++ b/changelog/v5.0.md
@@ -9,4 +9,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update cray-service chart to ~11.0.0
+- Update cray-service chart to ~11.0

--- a/changelog/v5.0.md
+++ b/changelog/v5.0.md
@@ -9,4 +9,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update cray-service chart to ~10.0.6
+- Update cray-service chart to ~11.0.0

--- a/changelog/v5.0.md
+++ b/changelog/v5.0.md
@@ -1,0 +1,12 @@
+# Changelog for v5.0
+
+All notable changes to this project for v5.X.Z will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [5.0.0] - 2024-08-30
+
+### Changed
+
+- Update cray-service chart to ~10.0.6 and docker-kubectl image to 1.24.17

--- a/changelog/v5.0.md
+++ b/changelog/v5.0.md
@@ -1,6 +1,6 @@
 # Changelog for v5.0
 
-All notable changes to this project for v5.X.Z will be documented in this file.
+All notable changes to this project for v5.0.Z will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/charts/v5.0/cray-hms-capmc/.gitignore
+++ b/charts/v5.0/cray-hms-capmc/.gitignore
@@ -1,0 +1,2 @@
+# by default we'll ignore any subcharts included, but simply adjust this if need be
+charts/*

--- a/charts/v5.0/cray-hms-capmc/Chart.yaml
+++ b/charts/v5.0/cray-hms-capmc/Chart.yaml
@@ -8,7 +8,7 @@ sources:
   - "https://github.com/Cray-HPE/hms-capmc"
 dependencies:
   - name: cray-service
-    version: "~10.0.6"
+    version: "~11.0.0"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 maintainers:
   - name: Hardware Management

--- a/charts/v5.0/cray-hms-capmc/Chart.yaml
+++ b/charts/v5.0/cray-hms-capmc/Chart.yaml
@@ -8,7 +8,7 @@ sources:
   - "https://github.com/Cray-HPE/hms-capmc"
 dependencies:
   - name: cray-service
-    version: "~11.0.0"
+    version: "~11.0"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 maintainers:
   - name: Hardware Management

--- a/charts/v5.0/cray-hms-capmc/Chart.yaml
+++ b/charts/v5.0/cray-hms-capmc/Chart.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v2
+name: "cray-hms-capmc"
+version: 5.0.0
+description: "Kubernetes resources for cray-hms-capmc"
+home: "https://github.com/Cray-HPE/hms-capmc-charts"
+sources:
+  - "https://github.com/Cray-HPE/hms-capmc"
+dependencies:
+  - name: cray-service
+    version: "~10.0.6"
+    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+maintainers:
+  - name: Hardware Management
+    url: https://github.com/orgs/Cray-HPE/teams/hardware-management
+appVersion: "3.6.0"
+annotations:
+  artifacthub.io/license: "MIT"

--- a/charts/v5.0/cray-hms-capmc/files/config.toml
+++ b/charts/v5.0/cray-hms-capmc/files/config.toml
@@ -1,0 +1,189 @@
+# Copyright 2019-2024 Hewlett Packard Enterprise Development LP
+#
+# This config file describes CAPMC operational configuration parameters.
+#
+
+# The NodeRules section describes rules/guidelines for CAPMC node control.
+# The get_note_rules API returns these values.
+[NodeRules]
+
+# Minimum time, in seconds, which a node must reamin in the off state
+# after a shutdown and power off operation. Use -1 for no limit.
+MinOffTime = -1
+
+# Maximum time, in seconds, which a node may be in the off state. Use -1
+# for no limit.
+MaxOffTime = -1
+
+# The NodeRules.Off subsection describes rules/guidelines for node_off.
+[NodeRules.Off]
+
+# Approximate time, in seconds, for a node cleanly shutdown and power off.
+Latency = 60
+
+# Maximum number of nodes which may be powered off at once. Use -1 for no limit.
+MaxRequest = -1
+
+# The NodeRules.On subsection describes rules/guidelines for node_on.
+[NodeRules.On]
+
+# Approximate time, in seconds, for a node to power on and boot to Ready state.
+Latency = 120
+
+# Maximum number of nodes which may be powered on at once. Use -1 for no limit.
+MaxRequest = -1
+
+# The NodeRules.Reinit subsection describes rules/guidelines for node_reint.
+[NodeRules.Reinit]
+
+# Approximate time, in seconds, for a node cleanly shutdown, power off, power
+# on, and boot to Ready state.
+Latency = 180
+
+# Maximum number of nodes allowed to be included in a node reinit request.
+# Use -1 for no limit.
+MaxRequest = -1
+
+# The PowerControls section describes guidelines/policy/rules applying
+# generally to CAPMC power off (down) / on (up) of hardware. These values
+# should only be edited under direction from Cray service personnel.
+[PowerControls]
+
+# The PowerControls.ForceOff subsection describes guidelines/policy/rules
+# applying to a force off action.
+[PowerControls.ForceOff]
+
+# Block components with these roles from power force off actions.
+# BlockRole = ["Management"]
+
+# An ordered list desribing the power force off sequence for components.
+ComponentSequence = ["Node", "ComputeModule", "HSNBoard", "RouterModule", "Chassis", "CabinetPDUOutlet", "CabinetPDUPowerConnector"]
+
+# Mapping of CAPMC force off to Redfish ResetType.
+ResetType = ["ForceOff"]
+
+# The PowerControls.ForceOn subsection describes guidelines/policy/rules
+# applying to a force on action.
+[PowerControls.ForceOn]
+
+# Block components with these roles from power force on actions.
+# BlockRole = ["Management"]
+
+# An ordered list desribing the power force on sequence for components.
+ComponentSequence = ["CabinetPDUPowerConnector", "CabinetPDUOutlet", "Chassis", "RouterModule", "HSNBoard", "ComputeModule", "Node"]
+
+# Mapping of CAPMC force on to Redfish ResetType.
+ResetType = ["ForceOn"]
+
+# The PowerControls.ForceRestart subsection describes guidelines/policy/rules
+# applying to a force restart (reinit) action.
+[PowerControls.ForceRestart]
+
+# Block components with these roles from power force restart actions.
+# BlockRole = ["Management"]
+
+# An ordered list desribing the power force restart sequence for components.
+ComponentSequence = ["Node"]
+
+# Mapping of CAPMC force restart (reinit) to Redfish ResetType.
+ResetType = ["ForceRestart", "PowerCycle"]
+
+# The PowerControls.off subsection describes guidelines/policy/rules
+# applying to an off action.
+[PowerControls.Off]
+
+# Block components with these roles from power off actions.
+# BlockRole = ["Management"]
+
+# An ordered list desribing the power off sequence for components.
+ComponentSequence = ["Node", "ComputeModule", "HSNBoard", "RouterModule", "Chassis", "CabinetPDUOutlet", "CabinetPDUPowerConnector"]
+
+# Mapping of CAPMC (graceful) off to Redfish ResetType.
+ResetType = ["GracefulShutdown", "PushPowerButton", "Off"]
+
+# The PowerControls.On subsection describes guidelines/policy/rules
+# applying to an on action.
+[PowerControls.On]
+
+# Block components with these roles from power on actions.
+# BlockRole = ["Management"]
+
+# An ordered list desribing the power on sequence for components.
+ComponentSequence = ["CabinetPDUPowerConnector", "CabinetPDUOutlet", "Chassis", "RouterModule", "HSNBoard", "ComputeModule", "Node"]
+
+# Mapping of CAPMC (graceful) on to Redfish ResetType.
+ResetType = ["On"]
+
+# The PowerControls.Resetart subsection describes guidelines/policy/rules
+# applying to a restart (AKA reinit) action.
+[PowerControls.Restart]
+
+# Block components with these roles from power restart actions.
+# BlockRole = ["Management"]
+
+# An ordered list desribing the power restart sequence for components.
+ComponentSequence = ["Node"]
+
+# Mapping of CAPMC (graceful) restart to Redfish ResetType.
+ResetType = ["GracefulRestart"]
+
+# NOTE NMI is a future CAPMC enhancement. Actual configuration TBD.
+[PowerControls.NMI]
+
+# Block components with these roles from a NMI action.
+# NOTE: "" covers any component without an assigned role.
+# BlockRole = ["Management"]
+
+# An ordered list desribing the NMI sequence for components.
+ComponentSequence = ["Node"]
+
+# Mapping of CAPMC NMI to Redfish ResetType.
+ResetType = ["Nmi"]
+
+[SystemParameters]
+
+# Administratively defined upper limit on system power
+PowerCapTarget = 0
+
+# System power level, which if crossed, will result in Cray management software
+# emitting over power budget warnings
+PowerThreshold = 0
+
+# Additional static system wide power overhead which is unreported, specified
+# in watts
+StaticPower = 0
+
+# True if out-of-band HSS power ramp rate limiting features are enabled
+RampLimited = false
+
+# Administratively defined maximum rate of change (increasing or decreasing) in
+# system wide power consumption, specified in watts per minute
+RampLimit = 2000000
+
+# Administratively defined minimum allowable system power consumption,
+# specified in watts
+PowerBandMin = 0
+
+# Administratively defined maximum allowable system power consumption,
+# specified in watts
+PowerBandMax = 0
+
+[CapmcConfiguration]
+
+# Number of workers that are available to execute in parallel for Redfish calls
+# ActionMaxWorkers = 1000
+
+# CAPMC behavior for a power action that target hardware does not support
+# Valid options: simulate, ignore, error
+#   simulate - For components that do not support GracefulRestart or
+#              ForceRestart, simulate will turn the node Off then On again
+#   ignore - Skip the component but notify the user it was ignored
+#   error - Halt the power operation and notify the user
+# OnUnsupportedAction = "simulate"
+
+# CAPMC will check power state of components when an Off request has been
+# issued. CAPMC will return from the Off request when it has verified that the
+# target components are off or if the number of retries have been exceeded.
+# WaitForOffRetries = 60
+# Amount of time to sleep between checks of component power state for Off.
+# WaitForOffSleep = 15

--- a/charts/v5.0/cray-hms-capmc/templates/configmap.yaml
+++ b/charts/v5.0/cray-hms-capmc/templates/configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cray-capmc-configuration
+  namespace: services
+data:
+  config.toml: |-
+{{ .Files.Get "files/config.toml" | indent 4 }}
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: capmc-cacert-info
+data:
+  CA_URI: "{{ .Values.hms_ca_uri }}"
+

--- a/charts/v5.0/cray-hms-capmc/templates/tests/check-hardware.yaml
+++ b/charts/v5.0/cray-hms-capmc/templates/tests/check-hardware.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-check-hardware"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "2" #run this after smoke and functional
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-check-hardware"
+
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-check-hardware"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-check-hardware"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "check-hardware"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: ["entrypoint.sh tavern -c /src/app/tavern_global_config_ct_test_production.yaml -p /src/app/api/1-hardware-checks"]

--- a/charts/v5.0/cray-hms-capmc/templates/tests/test-functional.yaml
+++ b/charts/v5.0/cray-hms-capmc/templates/tests/test-functional.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-functional"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "1" #run this after smoke!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-functional"
+
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-functional"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-functional"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "functional"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: ["entrypoint.sh tavern -c /src/app/tavern_global_config_ct_test_production.yaml -p /src/app/api/2-non-disruptive"]

--- a/charts/v5.0/cray-hms-capmc/templates/tests/test-smoke.yaml
+++ b/charts/v5.0/cray-hms-capmc/templates/tests/test-smoke.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-smoke"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1" #run this first!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-smoke"
+
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-smoke"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-smoke"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "smoke"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: ["entrypoint.sh smoke -f smoke.json -u http://cray-capmc"]

--- a/charts/v5.0/cray-hms-capmc/values.yaml
+++ b/charts/v5.0/cray-hms-capmc/values.yaml
@@ -1,0 +1,107 @@
+# Please refer to https://stash.us.cray.com/projects/CLOUD/repos/cray-charts/browse/stable/cray-service/values.yaml?at=refs%2Fheads%2Fmaster
+# for more info on values you can set/override
+# Note that cray-service.containers[*].image and cray-service.initContainers[*].image map values are one of the only structures that
+# differ from the standard kubernetes container spec:
+# image:
+#   repository: ""
+#   tag: "" (default = "latest")
+#   pullPolicy: "" (default = "IfNotPresent")
+
+global:
+  appVersion: 3.6.0
+  testVersion: 3.6.0
+
+image:
+  repository: artifactory.algol60.net/csm-docker/stable/cray-capmc
+  pullPolicy: IfNotPresent
+
+tests:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/cray-capmc-hmth-test
+    pullPolicy: IfNotPresent
+
+hms_ca_uri: ""
+
+cray-service:
+  type: "Deployment"
+  nameOverride: "cray-capmc"
+  fullnameOverride: "cray-capmc"
+  replicaCount: 3
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - cray-capmc
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 50%
+    type: RollingUpdate
+  containers:
+    cray-capmc:
+      name: "cray-capmc"
+      image:
+        repository: artifactory.algol60.net/csm-docker/stable/cray-capmc
+      ports:
+        - name: http
+          containerPort: 27777
+      env:
+        - name: HSM_URL
+          value: "http://cray-smd"
+        - name: PCS_URL
+          value: "http://cray-power-control"
+        - name: CAPMC_CONFIG
+          value: "/usr/local/etc/capmc-service/config.toml"
+        - name: VAULT_ADDR
+          value: "http://cray-vault.vault:8200"
+        - name: VAULT_SKIP_VERIFY
+          value: "true"
+        - name: CAPMC_CA_URI
+          valueFrom:
+            configMapKeyRef:
+              name: capmc-cacert-info
+              key: CA_URI
+      livenessProbe:
+        httpGet:
+          port: 27777
+          path: /capmc/v1/liveness
+        initialDelaySeconds: 10
+        periodSeconds: 20
+      readinessProbe:
+        httpGet:
+          port: 27777
+          path: /capmc/v1/readiness
+        initialDelaySeconds: 5
+        periodSeconds: 60
+      resources:
+        limits:
+          cpu: "10"
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 128Mi
+      volumeMounts:
+        - name: cray-capmc-config-vol
+          mountPath: /usr/local/etc/capmc-service/config.toml
+          readOnly: true
+          subPath: config.toml
+        - name: cray-pki-cacert-vol
+          mountPath: /usr/local/cray-pki
+  volumes:
+    cray-capmc-config-vol:
+      name: cray-capmc-config-vol
+      configMap:
+        name: cray-capmc-configuration
+    cray-pki-cacert-vol:
+      name: cray-pki-cacert-vol
+      configMap:
+        name: cray-configmap-ca-public-key
+
+  ingress:
+    enabled: true
+    uri: " "
+    prefix: /apis/capmc

--- a/cray-hms-capmc.compatibility.yaml
+++ b/cray-hms-capmc.compatibility.yaml
@@ -7,6 +7,7 @@ chartVersionToCSMVersion:
   ">=3.0.0": "~1.3.0"
   ">=4.0.0": "~1.4.0"
   ">=4.1.0": "~1.5.0" # 4.1.0 is the update to cray-service 10.0
+  ">=5.0.0": "~1.6.0" # 5.0.0 is the update to cray-service 10.0.6 and docker-kubectl 1.24.17
 
 # The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
@@ -34,6 +35,7 @@ chartVersionToApplicationVersion:
   "4.0.2": "3.3.0"
   "4.0.3": "3.6.0"
   "4.1.0": "3.6.0"
+  "5.0.0": "3.6.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []

--- a/cray-hms-capmc.compatibility.yaml
+++ b/cray-hms-capmc.compatibility.yaml
@@ -7,7 +7,7 @@ chartVersionToCSMVersion:
   ">=3.0.0": "~1.3.0"
   ">=4.0.0": "~1.4.0"
   ">=4.1.0": "~1.5.0" # 4.1.0 is the update to cray-service 10.0
-  ">=5.0.0": "~1.6.0" # 5.0.0 is the update to cray-service 10.0.6 and docker-kubectl 1.24.17
+  ">=5.0.0": "~1.6.0" # 5.0.0 is the update to cray-service 10.0.6
 
 # The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.

--- a/cray-hms-capmc.compatibility.yaml
+++ b/cray-hms-capmc.compatibility.yaml
@@ -1,13 +1,21 @@
 ---
 # CSM Version is not really following semver.
 chartVersionToCSMVersion:
+  # Summary:
+  #   Chart Version: 1.23.12 <= x.y.z < 2.0.0, CSM Version: 1.0.0 <= x.y.z < 1.2.0
+  #   Chart Version: 2.0.0   <= x.y.z < 3.0.0, CSM Version: 1.2.0 <= x.y.z < 1.3.0
+  #   Chart Version: 3.0.0   <= x.y.z < 4.0.0, CSM Version: 1.3.0 <= x.y.z < 1.4.0
+  #   Chart Version: 4.0.0   <= x.y.z < 4.1.0, CSM Version: 1.4.0 <= x.y.z < 1.5.0
+  #   Chart Version: 4.1.0   <= x.y.z < 5.0.0, CSM Version: 1.5.0 <= x.y.z < 1.6.0
+  #   Chart Version: 5.0.0   <= x.y.z,         CSM Version: 1.6.0 <= x.y.z
+  #
   # Chart version: CSM version
   "^1.23.12": "~1.0.0"
-  ">=2.0.0": "~1.2.0" # Chart Version: 2.0.0 <= x.y.z, CSM Version: 1.2.0 <= x.y.z < 1.3.0
+  ">=2.0.0": "~1.2.0"
   ">=3.0.0": "~1.3.0"
   ">=4.0.0": "~1.4.0"
   ">=4.1.0": "~1.5.0" # 4.1.0 is the update to cray-service 10.0
-  ">=5.0.0": "~1.6.0" # 5.0.0 is the update to cray-service 10.0.6
+  ">=5.0.0": "~1.6.0" # 6.0.0 contains features specific to k8s 1.24 or later
 
 # The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.

--- a/cray-hms-capmc.compatibility.yaml
+++ b/cray-hms-capmc.compatibility.yaml
@@ -15,7 +15,7 @@ chartVersionToCSMVersion:
   ">=3.0.0": "~1.3.0"
   ">=4.0.0": "~1.4.0"
   ">=4.1.0": "~1.5.0" # 4.1.0 is the update to cray-service 10.0
-  ">=5.0.0": "~1.6.0" # 6.0.0 contains features specific to k8s 1.24 or later
+  ">=5.0.0": "~1.6.0" # 5.0.0 contains features specific to k8s 1.24 or later
 
 # The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.


### PR DESCRIPTION
## Summary and Scope

In CSM 1.6 Kubernetes is being updated to 1.24

- Updated the cray-service chart to 11.0.0

Created new helm chart 5.0.0 for this.  There was no change in app version.

## Issues and Related PRs

* Resolves [CASMHMS-6261](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6261)

## Testing

Tested on:

  * `fanta` (running Kubernetes v1.24.17)

Test description:

All testing was done with the new cray-service 10.0.6.  After testing completed, was asked to use 11.0.0 instead of 10.0.6 but was informed that no testing of 11.0.0 was required to be done if already tested with 10.0.6 because it is the exact same, just a different version number.

- Upgraded to new chart with 'helm upgrade'
- Because pods don't restart after upgrade if there was no container change, manually restarted them with 'kubectl rollout restart deployment'
- Verified no errors in chart upgrade or restart of pods
- Ran test suite 'run_hms_ct_tests.sh -t capmc' and verified no failures
- Checked logs from service to verify nothing unusual present

Test Checklist:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable