### PR TITLE
CASMHMS-6512: Bump cray-service to latest version

### DIFF
--- a/changelog/v5.1.md
+++ b/changelog/v5.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v5.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.1] - 2025-05-13
+
+### Updated
+
+- Updated cray-service dependency to the latest version
+
 ## [5.1.0] - 2025-03-11
 
 ### Security

--- a/changelog/v5.1.md
+++ b/changelog/v5.1.md
@@ -5,11 +5,12 @@ All notable changes to this project for v5.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.1.1] - 2025-05-13
+## [5.1.1] - 2025-05-14
 
 ### Updated
 
 - Updated cray-service dependency to the latest version
+- Internal tracking ticket: CASMHMS-6512
 
 ## [5.1.0] - 2025-03-11
 

--- a/charts/v5.1/cray-hms-capmc/Chart.yaml
+++ b/charts/v5.1/cray-hms-capmc/Chart.yaml
@@ -1,14 +1,14 @@
 ---
 apiVersion: v2
 name: "cray-hms-capmc"
-version: 5.1.0
+version: 5.1.1
 description: "Kubernetes resources for cray-hms-capmc"
 home: "https://github.com/Cray-HPE/hms-capmc-charts"
 sources:
   - "https://github.com/Cray-HPE/hms-capmc"
 dependencies:
   - name: cray-service
-    version: "~11.0"
+    version: "~12.0"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 maintainers:
   - name: Hardware Management

--- a/cray-hms-capmc.compatibility.yaml
+++ b/cray-hms-capmc.compatibility.yaml
@@ -47,6 +47,7 @@ chartVersionToApplicationVersion:
   "4.1.0": "3.6.0"
   "5.0.0": "3.6.0"
   "5.1.0": "3.7.0"
+  "5.1.1": "3.7.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Updated cray-service dependency to the latest version

New helm chart version is 5.1.1 (no app version change)

### Issues and Related PRs

* Resolves [CASMHMS-6512](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6512)

### Testing

Tested on:

* `beau` (vshasta)

Test description:

- Helm upgrade of the new chart
- Had to do a 'rollout restart' to restart the pods since the container image didn't change
- Ran HMS CT tests
- Helm rollback to the prior version of the service

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable