### PR TITLE
CASMHMS-6390: Explicitly closed all request and response bodies

### DIFF
--- a/changelog/v5.1.md
+++ b/changelog/v5.1.md
@@ -5,7 +5,7 @@ All notable changes to this project for v5.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.1.2] - 2025-05-30
+## [5.1.2] - 2025-05-29
 
 ### Updated
 

--- a/changelog/v5.1.md
+++ b/changelog/v5.1.md
@@ -5,6 +5,16 @@ All notable changes to this project for v5.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.2] - 2025-05-30
+
+### Updated
+
+- Updated image and module dependencies
+- Updated Go vo v1.24
+- Explicitly closed all request and response bodies using hms-base functions
+- Fixed bug with jq use in runSnyk.sh
+- Internal tracking ticket: CASMHMS-6390
+
 ## [5.1.1] - 2025-05-14
 
 ### Updated

--- a/charts/v5.1/cray-hms-capmc/Chart.yaml
+++ b/charts/v5.1/cray-hms-capmc/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: "cray-hms-capmc"
-version: 5.1.1
+version: 5.1.2
 description: "Kubernetes resources for cray-hms-capmc"
 home: "https://github.com/Cray-HPE/hms-capmc-charts"
 sources:
@@ -13,6 +13,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "3.7.0"
+appVersion: "3.8.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v5.1/cray-hms-capmc/values.yaml
+++ b/charts/v5.1/cray-hms-capmc/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 3.7.0
-  testVersion: 3.7.0
+  appVersion: 3.8.0
+  testVersion: 3.8.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-capmc

--- a/cray-hms-capmc.compatibility.yaml
+++ b/cray-hms-capmc.compatibility.yaml
@@ -48,6 +48,7 @@ chartVersionToApplicationVersion:
   "5.0.0": "3.6.0"
   "5.1.0": "3.7.0"
   "5.1.1": "3.7.0"
+  "5.1.2": "3.8.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Updated all module and image dependencies to latest versions.  The primary reason for this was to pick up some resource leak fixes to the HMS module dependencies.

Used hms-base APIs for explicitly draining and closing http request and response bodies.

Updated Go to v1.24, which required some code changes to avoid some compile errors.

Fixed a bug with jq use when running runSnyk.sh

Adopted app version 3.8.0 for CSM 1.7.0 (helm chart 5.1.2).

### Issues and Related PRs

* Resolves [CASMHMS-6390](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6390)

### Testing

Tested on:

* `mug`

Test description:

Upgraded to dev version of service.  Watched log files to ensure nothing obvious was wrong.  Verified all CT tests still pass.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable