### PR TITLE
CASMHMS-6570: Convert PCS status requests from GET to POST

### DIFF
--- a/.github/workflows/k8s_api_checker.yaml
+++ b/.github/workflows/k8s_api_checker.yaml
@@ -2,5 +2,5 @@ name: Kubernetes API Checker
 on: [push, pull_request, workflow_dispatch]
 jobs:
   k8s_api_checker:
-    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/k8s_api_checker.yaml@v2
+    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/k8s_api_checker.yaml@v4
     secrets: inherit

--- a/changelog/v5.0.md
+++ b/changelog/v5.0.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Convert PCS status requests from GET to POST
 - Update CT docker-compose file to use CSM 1.6.3 versions of HMS services
+- Update chart build usage of k8s_api_checker.yaml workflow from v2 to v4
 - Internal tracking ticket: CASMHMS-6570
 
 ## [5.0.0] - 2024-08-30

--- a/changelog/v5.0.md
+++ b/changelog/v5.0.md
@@ -5,7 +5,7 @@ All notable changes to this project for v5.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.1] - 2025-08-14
+## [5.0.1] - 2025-08-19
 
 ### Fixed
 

--- a/changelog/v5.0.md
+++ b/changelog/v5.0.md
@@ -5,6 +5,13 @@ All notable changes to this project for v5.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.1] - 2025-08-14
+
+### Fixed
+
+- Convert PCS status requests from GET to POST
+- Internal tracking ticket: CASMHMS-6570
+
 ## [5.0.0] - 2024-08-30
 
 ### Changed

--- a/changelog/v5.0.md
+++ b/changelog/v5.0.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Convert PCS status requests from GET to POST
+- Update CT docker-compose file to use CSM 1.6.3 versions of HMS services
 - Internal tracking ticket: CASMHMS-6570
 
 ## [5.0.0] - 2024-08-30

--- a/changelog/v5.1.md
+++ b/changelog/v5.1.md
@@ -5,7 +5,7 @@ All notable changes to this project for v5.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.1.3] - 2025-08-14
+## [5.1.3] - 2025-08-19
 
 ### Fixed
 

--- a/changelog/v5.1.md
+++ b/changelog/v5.1.md
@@ -5,6 +5,13 @@ All notable changes to this project for v5.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.3] - 2025-08-14
+
+### Fixed
+
+- Convert PCS status requests from GET to POST
+- Internal tracking ticket: CASMHMS-6570
+
 ## [5.1.2] - 2025-05-29
 
 ### Updated

--- a/changelog/v5.1.md
+++ b/changelog/v5.1.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Convert PCS status requests from GET to POST
+- Update chart build usage of k8s_api_checker.yaml workflow from v2 to v4
 - Internal tracking ticket: CASMHMS-6570
 
 ## [5.1.2] - 2025-05-29

--- a/charts/v5.0/cray-hms-capmc/Chart.yaml
+++ b/charts/v5.0/cray-hms-capmc/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: "cray-hms-capmc"
-version: 5.0.0
+version: 5.0.1
 description: "Kubernetes resources for cray-hms-capmc"
 home: "https://github.com/Cray-HPE/hms-capmc-charts"
 sources:
@@ -13,6 +13,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "3.6.0"
+appVersion: "3.6.1"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v5.0/cray-hms-capmc/values.yaml
+++ b/charts/v5.0/cray-hms-capmc/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 3.6.0
-  testVersion: 3.6.0
+  appVersion: 3.6.1
+  testVersion: 3.6.1
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-capmc

--- a/charts/v5.1/cray-hms-capmc/Chart.yaml
+++ b/charts/v5.1/cray-hms-capmc/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: "cray-hms-capmc"
-version: 5.1.2
+version: 5.1.3
 description: "Kubernetes resources for cray-hms-capmc"
 home: "https://github.com/Cray-HPE/hms-capmc-charts"
 sources:
@@ -13,6 +13,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "3.8.0"
+appVersion: "3.9.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v5.1/cray-hms-capmc/values.yaml
+++ b/charts/v5.1/cray-hms-capmc/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 3.8.0
-  testVersion: 3.8.0
+  appVersion: 3.9.0
+  testVersion: 3.9.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-capmc

--- a/cray-hms-capmc.compatibility.yaml
+++ b/cray-hms-capmc.compatibility.yaml
@@ -46,9 +46,11 @@ chartVersionToApplicationVersion:
   "4.0.3": "3.6.0"
   "4.1.0": "3.6.0"
   "5.0.0": "3.6.0"
+  "5.0.1": "3.6.1"
   "5.1.0": "3.7.0"
   "5.1.1": "3.7.0"
   "5.1.2": "3.8.0"
+  "5.1.3": "3.9.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Customer reported CT test failures showing a capmc CT test constructing GET status requests to PCS with URLs containing too many characters due to specifying all xnames in the system.  This PR changes capmc from using GET to POST for PCS status requests so that lengthy lists of xnames are passed in the request body rather than encoded into the URL.

Changes in capmc's test environment were also required as part of this change.

The 1.6.3 PR included some changes not required by the 1.7.0 PR.  The CT docker-compose file was referencing an old version of PCS that did not have POST support for component status.  I updated the docker-compose file to reference the version of PCS in the CSM 1.6.3 release as well as 1.6.3 versions of other HMS components.

Also updated chart build usage of k8s_api_checker.yaml workflow from v2 to v4 because we were having build issues.

Adopted app version 3.6.1 for CSM 1.6.3 (helm chart 5.0.1)
Adopted app version 3.9.0 for CSM 1.7.0 (helm chart 5.1.3)

### Issues and Related PRs

* Resolves [CASMHMS-6570](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6570)

### Testing

#### Tested on:

* Laptop
* `rocket` (1.6.3 system)

#### Test Description:

Loaded dev version of capmc on to rocket.  Watched both capmc and PCS logs for issues.  Ran various capmc status requests to ensure properly formated requests and responses passed between capmc and PCS.

Ran the capmc CT smoke and integration tests.

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable