### PR TITLE
CASMHMS-6602: Update CAPMC dependencies

### DIFF
--- a/changelog/v5.1.md
+++ b/changelog/v5.1.md
@@ -5,6 +5,14 @@ All notable changes to this project for v5.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.4] - 2025-09-26
+
+### Security
+
+- Updated Alpine base image to pick up security fixes
+- Updated HMS image and Go module version dependencies
+- Internal tracking ticket: CASMHMS-6602
+
 ## [5.1.3] - 2025-08-19
 
 ### Fixed

--- a/charts/v5.1/cray-hms-capmc/Chart.yaml
+++ b/charts/v5.1/cray-hms-capmc/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: "cray-hms-capmc"
-version: 5.1.3
+version: 5.1.4
 description: "Kubernetes resources for cray-hms-capmc"
 home: "https://github.com/Cray-HPE/hms-capmc-charts"
 sources:
@@ -13,6 +13,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "3.9.0"
+appVersion: "3.10.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v5.1/cray-hms-capmc/values.yaml
+++ b/charts/v5.1/cray-hms-capmc/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 3.9.0
-  testVersion: 3.9.0
+  appVersion: 3.10.0
+  testVersion: 3.10.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-capmc

--- a/cray-hms-capmc.compatibility.yaml
+++ b/cray-hms-capmc.compatibility.yaml
@@ -51,6 +51,7 @@ chartVersionToApplicationVersion:
   "5.1.1": "3.7.0"
   "5.1.2": "3.8.0"
   "5.1.3": "3.9.0"
+  "5.1.4": "3.10.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Updated Alpine base image from 3.21 to 3.22 to pick up security fixes.

Updated all of the HMS and Go module image dependencies.

Adopted app version 3.10.0 for CSM 1.7.1 (helm chart 5.1.4)

### Issues and Related PRs

* Resolves [CASMHMS-6602](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6602)

### Testing

Tested via pipeline execution of CT tests and on system mug.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable